### PR TITLE
Remove readonly from Trade attributes

### DIFF
--- a/src/entities/fractions/tokenAmount.ts
+++ b/src/entities/fractions/tokenAmount.ts
@@ -11,7 +11,7 @@ import { Fraction } from './fraction'
 const Big = toFormat(_Big)
 
 export class TokenAmount extends Fraction {
-  public readonly token: Token
+  public token: Token
 
   // amount _must_ be raw, i.e. in the native representation
   constructor(token: Token, amount: BigintIsh) {

--- a/src/entities/trade.ts
+++ b/src/entities/trade.ts
@@ -76,8 +76,8 @@ export interface BestTradeOptions {
 export class Trade {
   public readonly route: Route
   public readonly tradeType: TradeType
-  public readonly inputAmount: TokenAmount
-  public readonly outputAmount: TokenAmount
+  public inputAmount: TokenAmount
+  public outputAmount: TokenAmount
   public readonly executionPrice: Price
   public readonly nextMidPrice: Price
   public readonly slippage: Percent


### PR DESCRIPTION
This modification (hack) is necessary for the Wrap/Unwrap functionality in vexchange-interface.
Here are the functions I need the modification for:
https://github.com/vexchange/vexchange-interface/blob/b7b1b43ad571f9498f014d39c1fff3c849ce62f5/src/hooks/Trades.ts#L43-L100